### PR TITLE
Allow port to be set independently.

### DIFF
--- a/lib/deploy/recipes/deploy.rb
+++ b/lib/deploy/recipes/deploy.rb
@@ -4,7 +4,7 @@ Capistrano::Configuration.instance(:must_exist).load do
   set :default_environment, {:environment => "#{shared_path}/config/environment"}
   set :deploy_via,          :remote_cache
   set :keep_releases,       2
-  set :port,                1022
+  set :port,                fetch(:port)           { 1022 }
   set :scm,                 :git
   set :user,                'edhdev'
   set :use_sudo,            false

--- a/lib/deploy/version.rb
+++ b/lib/deploy/version.rb
@@ -1,3 +1,3 @@
 module Deploy
-  VERSION = "0.0.14"
+  VERSION = "0.0.15"
 end


### PR DESCRIPTION
Keep default of 1022, but don't overwrite an already set value.
